### PR TITLE
Task 3: Undo add and remove from reading list

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -11,4 +11,69 @@ describe('When: I use the reading list feature', () => {
       'My Reading List'
     );
   });
+
+  describe('When: I use the add or remove feature with snack-bar functionality', () => {
+    beforeEach(() => {
+      cy.get('input[type="search"]').type('java script');
+      cy.get('form').submit()
+    });
+    
+    it('Then: I should be able to add book to the reading list and undo it', () => {
+      /* counting reading list items */
+      const readingListItems = cy.$$('[data-testing="reading-list"]').length;
+
+      /* Adding a book to reading list */
+      cy.get('[data-testing="want-to-read-cta"]:enabled').first().click();
+
+      /* checking reading list count value */
+      cy.get('[data-testing="reading-list"]').should(
+        'have.length',
+        readingListItems + 1
+      );
+
+      /* clicking snack-bar undo button */
+      cy.get(".mat-simple-snackbar-action").click();
+
+      /* verfying that book is removed from reading list */
+      cy.get('[data-testing="reading-list"]').should(
+        'have.length',
+        readingListItems
+      );
+    });
+    
+    it('Then: I should be able to remove book from the reading list and undo it', () => {
+      /* counting reading list items */
+      const readingListItems = cy.$$('[data-testing="reading-list"]').length;
+
+      /* Adding a book to reading list */
+      cy.get('[data-testing="want-to-read-cta"]:enabled').first().click();
+
+      /* opening reading list */
+      cy.get('[data-testing="toggle-reading-list"]').click();
+
+      /* checking reading list count value */
+      cy.get('[data-testing="reading-list"]').should(
+        'have.length',
+        readingListItems + 1
+      );
+
+      /* removing book from reading list */
+      cy.get('[data-testing="remove-from-reading-list-cta"]').last().click();
+
+      /* verifying book is removed from reading list */
+      cy.get('[data-testing="reading-list"]').should(
+        'have.length',
+        readingListItems
+      );
+
+      /* clicking snack-bar undo button */
+      cy.get(".mat-simple-snackbar-action").last().click();
+
+      /* verfying that book is added to reading list */
+      cy.get('[data-testing="reading-list"]').should(
+        'have.length',
+        readingListItems + 1
+      );
+    });
+  })
 });

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -14,7 +14,7 @@ export const loadReadingListError = createAction(
 
 export const addToReadingList = createAction(
   '[Books Search Results] Add to list',
-  props<{ book: Book }>()
+  props<{ book: Book, showSnackBar: boolean }>()
 );
 
 export const failedAddToReadingList = createAction(
@@ -24,12 +24,12 @@ export const failedAddToReadingList = createAction(
 
 export const confirmedAddToReadingList = createAction(
   '[Reading List API] Confirmed add to list',
-  props<{ book: Book }>()
+  props<{ book: Book, showSnackBar: boolean  }>()
 );
 
 export const removeFromReadingList = createAction(
   '[Books Search Results] Remove from list',
-  props<{ item: ReadingListItem }>()
+  props<{ item: ReadingListItem, showSnackBar: boolean }>()
 );
 
 export const failedRemoveFromReadingList = createAction(
@@ -39,5 +39,5 @@ export const failedRemoveFromReadingList = createAction(
 
 export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
-  props<{ item: ReadingListItem }>()
+  props<{ item: ReadingListItem, showSnackBar: boolean  }>()
 );

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -4,7 +4,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 
-import { SharedTestingModule } from '@tmo/shared/testing';
+import { createBook, createReadingListItem, SharedTestingModule } from '@tmo/shared/testing';
 import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
 
@@ -40,6 +40,40 @@ describe('ToReadEffects', () => {
       });
 
       httpMock.expectOne('/api/reading-list').flush([]);
+    });
+  });
+
+  describe('addBook$', () => {
+    it('should dispatch confirmedAddToReadingList action', done => {
+      actions = new ReplaySubject();
+      const book = createBook('A');
+      actions.next(ReadingListActions.addToReadingList({ book, showSnackBar: true }));
+
+      effects.addBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedAddToReadingList({ book, showSnackBar: true })
+        );
+        done();
+      });
+
+      httpMock.expectOne('/api/reading-list').flush([]);
+    });
+  });
+
+  describe('removeBook$', () => {
+    it('should dispatch confirmedRemoveFromReadingList action', done => {
+      actions = new ReplaySubject();
+      const item = createReadingListItem('A');
+      actions.next(ReadingListActions.removeFromReadingList({ item, showSnackBar: true }));
+
+      effects.removeBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedRemoveFromReadingList({ item, showSnackBar: true })
+        );
+        done();
+      });
+
+      httpMock.expectOne(`/api/reading-list/${item.bookId}`).flush([]);
     });
   });
 });

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -27,9 +27,9 @@ export class ReadingListEffects implements OnInitEffects {
   addBook$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.addToReadingList),
-      concatMap(({ book }) =>
+      concatMap(({ book, showSnackBar }) =>
         this.http.post('/api/reading-list', book).pipe(
-          map(() => ReadingListActions.confirmedAddToReadingList({ book })),
+          map(() => ReadingListActions.confirmedAddToReadingList({ book, showSnackBar })),
           catchError(() =>
             of(ReadingListActions.failedAddToReadingList({ book }))
           )
@@ -41,10 +41,10 @@ export class ReadingListEffects implements OnInitEffects {
   removeBook$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.removeFromReadingList),
-      concatMap(({ item }) =>
+      concatMap(({ item, showSnackBar }) =>
         this.http.delete(`/api/reading-list/${item.bookId}`).pipe(
           map(() =>
-            ReadingListActions.confirmedRemoveFromReadingList({ item })
+            ReadingListActions.confirmedRemoveFromReadingList({ item, showSnackBar })
           ),
           catchError(() =>
             of(ReadingListActions.failedRemoveFromReadingList({ item }))

--- a/libs/books/data-access/src/lib/+state/snack-bar.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/snack-bar.effects.spec.ts
@@ -1,0 +1,56 @@
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { SharedTestingModule, createBook, createReadingListItem, MatSnackBarMock } from '@tmo/shared/testing';
+import * as ReadingListActions from './reading-list.actions';
+import { SnackBarEffects } from './snack-bar.effects';
+
+describe('ToReadEffects', () => {
+    let actions: ReplaySubject<any>;
+    let effects: SnackBarEffects;
+    let snackBarService: MatSnackBar;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [SharedTestingModule, MatSnackBarModule],
+            providers: [
+                SnackBarEffects,
+                provideMockActions(() => actions),
+                provideMockStore(),
+                {
+                    provide: MatSnackBar, useClass: MatSnackBarMock
+                }
+            ]
+        });
+        effects = TestBed.inject(SnackBarEffects);
+        snackBarService = TestBed.inject(MatSnackBar);
+    });
+
+    describe('confirmAddToReadingList$', () => {
+        it('should open the snack bar when confirmedAddToReadingList action is dispatched', done => {
+            actions = new ReplaySubject();
+            spyOn(snackBarService, 'open').and.callThrough();
+            actions.next(ReadingListActions.confirmedAddToReadingList({ book: createBook('A'), showSnackBar: true }));
+
+            effects.confirmAddToReadingList$.subscribe(() => {
+                expect(snackBarService.open).toHaveBeenCalledWith("Book added to reading list.", "Undo", { "duration": 5000 });
+                done();
+            });
+        });
+    });
+
+    describe('confirmRemoveFromReadingList$', () => {
+        it('should open the snack bar when confirmedRemoveFromReadingList action is dispatched', done => {
+            actions = new ReplaySubject();
+            spyOn(snackBarService, 'open').and.callThrough();
+            actions.next(ReadingListActions.confirmedRemoveFromReadingList({ item: createReadingListItem('A'), showSnackBar: true }));
+
+            effects.confirmRemoveFromReadingList$.subscribe(() => {
+                expect(snackBarService.open).toHaveBeenCalledWith("Book removed from the list.", "Undo", { "duration": 5000 });
+                done();
+            });
+        });
+    });
+});

--- a/libs/books/data-access/src/lib/+state/snack-bar.effects.ts
+++ b/libs/books/data-access/src/lib/+state/snack-bar.effects.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { tap } from 'rxjs/operators';
+import * as ReadingListActions from './reading-list.actions';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
+
+@Injectable()
+export class SnackBarEffects {
+    confirmAddToReadingList$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ReadingListActions.confirmedAddToReadingList),
+            tap(({ book, showSnackBar }) => {
+                if (showSnackBar) {
+                    this.showSnackBar(book, 'Book added to reading list.', true);
+                }
+            })
+        ), { dispatch: false }
+    );
+
+    confirmRemoveFromReadingList$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ReadingListActions.confirmedRemoveFromReadingList),
+            tap(({ item, showSnackBar }) => {
+                if (showSnackBar) {
+                    this.showSnackBar(item, 'Book removed from the list.', false);
+                }
+            })
+        ), { dispatch: false }
+    );
+
+    constructor(private actions$: Actions, private matSnackBar: MatSnackBar, private store: Store) { }
+
+    showSnackBar(item, message: string, isAdded: boolean) {
+        this.matSnackBar
+            .open(message, 'Undo', { duration: 5000 })
+            .onAction()
+            .subscribe(() => {
+                if (isAdded) {
+                    this.store.dispatch(ReadingListActions.removeFromReadingList({ item: { bookId: item.id, ...item }, showSnackBar: false }));
+                } else {
+                    this.store.dispatch(ReadingListActions.addToReadingList({ book: { id: item.bookId, ...item }, showSnackBar: false }));
+                }
+            });
+    }
+}

--- a/libs/books/data-access/src/lib/books-data-access.module.ts
+++ b/libs/books/data-access/src/lib/books-data-access.module.ts
@@ -6,6 +6,7 @@ import * as fromBooks from './+state/books.reducer';
 import { BooksEffects } from './+state/books.effects';
 import * as fromReadingList from './+state/reading-list.reducer';
 import { ReadingListEffects } from './+state/reading-list.effects';
+import { SnackBarEffects } from './+state/snack-bar.effects';
 
 @NgModule({
   imports: [
@@ -15,7 +16,7 @@ import { ReadingListEffects } from './+state/reading-list.effects';
       fromReadingList.READING_LIST_FEATURE_KEY,
       fromReadingList.reducer
     ),
-    EffectsModule.forFeature([BooksEffects, ReadingListEffects])
+    EffectsModule.forFeature([BooksEffects, ReadingListEffects, SnackBarEffects])
   ]
 })
 export class BooksDataAccessModule {}

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -43,6 +43,7 @@
                 (click)="addBookToReadingList(book)"
                 [disabled]="book.isAdded"
                 [attr.aria-label]="'Want to Read ' + book.title + ' book'"
+                data-testing="want-to-read-cta"
               >
                 Want to Read
               </button>

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -35,7 +35,7 @@ export class BookSearchComponent {
   }
 
   addBookToReadingList(book: Book): void {
-    this.store.dispatch(addToReadingList({ book }));
+    this.store.dispatch(addToReadingList({ book, showSnackBar: true }));
   }
 
   searchExample(): void {

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="(readingList$ | async) as readingList">
   <ng-container *ngIf="readingList.length; else empty">
-    <div class="reading-list-item" *ngFor="let book of readingList">
+    <div class="reading-list-item" data-testing="reading-list" *ngFor="let book of readingList">
       <div>
         <img class="reading-list-item--cover" [src]="book.coverUrl" alt="" />
       </div>
@@ -16,6 +16,7 @@
           color="warn"
           [attr.aria-label]="'Remove ' + book.title + ' from reading list'"
           (click)="removeFromReadingList(book)"
+          data-testing="remove-from-reading-list-cta"
         >
           <mat-icon>remove_circle</mat-icon>
         </button>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -15,6 +15,6 @@ export class ReadingListComponent {
   constructor(private readonly store: Store) {}
 
   removeFromReadingList(item: ReadingListItem): void {
-    this.store.dispatch(removeFromReadingList({ item }));
+    this.store.dispatch(removeFromReadingList({ item, showSnackBar: true }));
   }
 }

--- a/libs/shared/testing/src/lib/model-factories.ts
+++ b/libs/shared/testing/src/lib/model-factories.ts
@@ -1,4 +1,5 @@
 import { Book, ReadingListItem } from '@tmo/shared/models';
+import { of } from 'rxjs';
 
 export function createBook(id: string): Book {
   return {
@@ -21,3 +22,11 @@ export function createReadingListItem(bookId: string): ReadingListItem {
     publishedDate: new Date(2020, 0, 1).toISOString()
   };
 }
+
+export class MatSnackBarMock {
+  open() {
+    return {
+      onAction: () => of()
+    };
+  }
+};


### PR DESCRIPTION
**As part of this task:**
- Showing mat-snack-bar on add or remove book action to show message.
- Added undo functionality on snack-bar to undo add or remove action.

**Working Application:**
![task 3 working application1](https://user-images.githubusercontent.com/86105460/125072952-e71e1c00-e0d8-11eb-8e97-321d6006c4be.PNG)


![task 3 working application2](https://user-images.githubusercontent.com/86105460/125072928-dec5e100-e0d8-11eb-9082-ad87163fd1ee.PNG)


**Lint test:**
![task 3 lint](https://user-images.githubusercontent.com/86105460/125072878-c8b82080-e0d8-11eb-9c1b-7d169e3b0202.PNG)



**Test cases:**
![task 3 test cases](https://user-images.githubusercontent.com/86105460/125072896-d077c500-e0d8-11eb-871d-1eac68d74d6c.PNG)



**E2E test cases:**
![task 3 e2e](https://user-images.githubusercontent.com/86105460/125072911-d7063c80-e0d8-11eb-96db-cff48ac1a2cd.PNG)


